### PR TITLE
Fix test/ld/1-omc/programs/eight-queens.oo

### DIFF
--- a/test/ld/1-omc/programs/eight-queens.oo
+++ b/test/ld/1-omc/programs/eight-queens.oo
@@ -257,20 +257,20 @@
     71 8C 8C 08     ; sub rsp rsp 8
 
     ; iterate over y from 0 to 8
-    79 00 8E F8     ; stw 0 rfp -8    ; y=0
+    79 00 8D F8     ; stw 0 rfp -8    ; y=0
 :print_board_next_y
 
         ; iterate over x from 0 to 8
-        79 00 8E FC     ; stw 0 rfp -4    ; x=0
+        79 00 8D FC     ; stw 0 rfp -4    ; x=0
         :print_board_next_x
 
             ; check whether there is a queen in this position.
-            78 83 8E FC     ; ldw r3 rfp -4
+            78 83 8D FC     ; ldw r3 rfp -4
             7C 88 <queens   ; ims r8 <queens
             7C 88 >queens   ; ims r8 >queens
             70 88 8E 88     ; add r8 rpp r8
             7A 87 88 83     ; ldb r7 r8 r3
-            78 84 8E F8     ; ldw r4 rfp -8
+            78 84 8D F8     ; ldw r4 rfp -8
             71 87 87 84     ; sub r7 r7 r4
 
             ; choose the character to emit, either "Q" or "."
@@ -291,9 +291,9 @@
             70 8C 8C 04       ; add rsp rsp 4     ; pop return address
 
             ; increment x
-            78 83 8E FC    ; ldw r3 rfp -4
+            78 83 8D FC    ; ldw r3 rfp -4
             70 83 83 01    ; add r3 r3 1   ; inc r3
-            79 83 8E FC    ; stw r3 rfp -4
+            79 83 8D FC    ; stw r3 rfp -4
 
             ; break if x == 8
             71 87 83 08    ; sub ra r3 8
@@ -324,9 +324,9 @@
         70 8C 8C 04       ; add rsp rsp 4     ; pop return address
 
         ; next y
-        78 84 8E F8    ; ldw r4 rfp -8
+        78 84 8D F8    ; ldw r4 rfp -8
         70 84 84 01    ; add r4 r4 1   ; inc r4
-        79 84 8E F8    ; stw r4 rfp -8
+        79 84 8D F8    ; stw r4 rfp -8
         71 87 84 08    ; sub ra r4 8
         7E 87 &print_board_done_y    ; jz ra &print_board_done_y
         7E 00 &print_board_next_y    ; jz 0 &print_board_next_y


### PR DESCRIPTION
3d018cb49befaf2cad4884302811718e12da6671 introduced typos into test/ld/1-omc/programs/eight-queens.oo

The problem passed tests because wrong instructions updated word at rpp-4, i.e. the word before program start which, I think, contains working directory path unused by the program.